### PR TITLE
Add basic Pokedex using PokeAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Pokedex--SwiftUI
+
+This simple SwiftUI app displays the first 151 Pokémon using data from [PokeAPI](https://pokeapi.co/). The list is shown in a modern adaptive grid and each entry loads its sprite asynchronously.
+
+Run the project in Xcode to see the Pokédex in action.

--- a/pokedexSwiftUI/ContentView.swift
+++ b/pokedexSwiftUI/ContentView.swift
@@ -1,21 +1,37 @@
-//
-//  ContentView.swift
-//  pokedexSwiftUI
-//
-//  Created by Denis Coder on 6/9/25.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var viewModel = PokedexViewModel()
+    private let columns = [GridItem(.adaptive(minimum: 80))]
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        NavigationStack {
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 16) {
+                    ForEach(viewModel.pokemon) { pokemon in
+                        VStack {
+                            AsyncImage(url: pokemon.imageURL) { image in
+                                image.resizable()
+                                    .aspectRatio(contentMode: .fit)
+                            } placeholder: {
+                                ProgressView()
+                            }
+                            .frame(width: 72, height: 72)
+                            Text(pokemon.name)
+                                .font(.caption)
+                                .lineLimit(1)
+                        }
+                        .padding(4)
+                        .background(RoundedRectangle(cornerRadius: 8).fill(Color(.systemGray6)))
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Pokédex")
         }
-        .padding()
+        .task {
+            await viewModel.fetchPokemon()
+        }
     }
 }
 

--- a/pokedexSwiftUI/Models/Pokemon.swift
+++ b/pokedexSwiftUI/Models/Pokemon.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct PokemonEntry: Decodable {
+    let name: String
+    let url: String
+}
+
+struct Pokemon: Identifiable {
+    let id: Int
+    let name: String
+    var imageURL: URL {
+        URL(string: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/\(id).png")!
+    }
+}
+
+struct PokemonList: Decodable {
+    let results: [PokemonEntry]
+}

--- a/pokedexSwiftUI/ViewModels/PokedexViewModel.swift
+++ b/pokedexSwiftUI/ViewModels/PokedexViewModel.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+@MainActor
+class PokedexViewModel: ObservableObject {
+    @Published var pokemon: [Pokemon] = []
+
+    func fetchPokemon() async {
+        guard let url = URL(string: "https://pokeapi.co/api/v2/pokemon?limit=151") else { return }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            let list = try JSONDecoder().decode(PokemonList.self, from: data)
+            pokemon = list.results.enumerated().compactMap { index, entry in
+                let parts = entry.url.split(separator: "/")
+                let idString = parts.last ?? "0"
+                let id = Int(idString) ?? index + 1
+                return Pokemon(id: id, name: entry.name.capitalized)
+            }
+        } catch {
+            print("Failed to fetch Pokémon: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- build simple view model and models for fetching Pokémon data
- show Pokémon in an adaptive grid with images and names
- update README with short description

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684731fa7b50832eac1cbf5ff987ed4c