### PR TITLE
Improve Pokédex grid and styling

### DIFF
--- a/pokedexSwiftUI/ContentView.swift
+++ b/pokedexSwiftUI/ContentView.swift
@@ -2,7 +2,25 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject private var viewModel = PokedexViewModel()
-    private let columns = [GridItem(.adaptive(minimum: 80))]
+    private let columns = [GridItem(.flexible()), GridItem(.flexible())]
+
+    private func color(for type: String) -> Color {
+        switch type {
+        case "fire": return .red
+        case "water": return .blue
+        case "grass": return .green
+        case "electric": return .yellow
+        case "poison": return .purple
+        case "bug": return .green.opacity(0.7)
+        case "ground": return .brown
+        case "psychic": return .pink
+        case "rock": return .gray
+        case "ghost": return .indigo
+        case "ice": return .cyan
+        case "dragon": return .orange
+        default: return Color(.systemGray6)
+        }
+    }
 
     var body: some View {
         NavigationStack {
@@ -16,13 +34,14 @@ struct ContentView: View {
                             } placeholder: {
                                 ProgressView()
                             }
-                            .frame(width: 72, height: 72)
+                            .frame(width: 96, height: 96)
                             Text(pokemon.name)
-                                .font(.caption)
+                                .font(.headline)
+                                .fontWeight(.semibold)
                                 .lineLimit(1)
                         }
-                        .padding(4)
-                        .background(RoundedRectangle(cornerRadius: 8).fill(Color(.systemGray6)))
+                        .padding(8)
+                        .background(RoundedRectangle(cornerRadius: 8).fill(color(for: pokemon.primaryType)))
                     }
                 }
                 .padding()

--- a/pokedexSwiftUI/Models/Pokemon.swift
+++ b/pokedexSwiftUI/Models/Pokemon.swift
@@ -8,9 +8,13 @@ struct PokemonEntry: Decodable {
 struct Pokemon: Identifiable {
     let id: Int
     let name: String
+    let types: [String]
+
     var imageURL: URL {
         URL(string: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/\(id).png")!
     }
+
+    var primaryType: String { types.first ?? "" }
 }
 
 struct PokemonList: Decodable {


### PR DESCRIPTION
## Summary
- show Pokémon in two columns
- enlarge sprites and style names
- fetch Pokémon types and color code cells

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684733f76948832ebfdd88c14efe3522