### PR TITLE
Add detail view and soften design

### DIFF
--- a/pokedexSwiftUI/ContentView.swift
+++ b/pokedexSwiftUI/ContentView.swift
@@ -2,50 +2,46 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject private var viewModel = PokedexViewModel()
-    private let columns = [GridItem(.flexible()), GridItem(.flexible())]
 
     private func color(for type: String) -> Color {
         switch type {
-        case "fire": return .red
-        case "water": return .blue
-        case "grass": return .green
-        case "electric": return .yellow
-        case "poison": return .purple
-        case "bug": return .green.opacity(0.7)
-        case "ground": return .brown
-        case "psychic": return .pink
-        case "rock": return .gray
-        case "ghost": return .indigo
-        case "ice": return .cyan
-        case "dragon": return .orange
+        case "fire": return .red.opacity(0.3)
+        case "water": return .blue.opacity(0.3)
+        case "grass": return .green.opacity(0.3)
+        case "electric": return .yellow.opacity(0.3)
+        case "poison": return .purple.opacity(0.3)
+        case "bug": return .green.opacity(0.3)
+        case "ground": return .brown.opacity(0.3)
+        case "psychic": return .pink.opacity(0.3)
+        case "rock": return .gray.opacity(0.3)
+        case "ghost": return .indigo.opacity(0.3)
+        case "ice": return .cyan.opacity(0.3)
+        case "dragon": return .orange.opacity(0.3)
         default: return Color(.systemGray6)
         }
     }
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                LazyVGrid(columns: columns, spacing: 16) {
-                    ForEach(viewModel.pokemon) { pokemon in
-                        VStack {
-                            AsyncImage(url: pokemon.imageURL) { image in
-                                image.resizable()
-                                    .aspectRatio(contentMode: .fit)
-                            } placeholder: {
-                                ProgressView()
-                            }
-                            .frame(width: 96, height: 96)
-                            Text(pokemon.name)
-                                .font(.headline)
-                                .fontWeight(.semibold)
-                                .lineLimit(1)
+            List(viewModel.pokemon) { pokemon in
+                NavigationLink(destination: PokemonDetailView(pokemon: pokemon)) {
+                    HStack {
+                        AsyncImage(url: pokemon.imageURL) { image in
+                            image.resizable()
+                                .aspectRatio(contentMode: .fit)
+                        } placeholder: {
+                            ProgressView()
                         }
-                        .padding(8)
-                        .background(RoundedRectangle(cornerRadius: 8).fill(color(for: pokemon.primaryType)))
+                        .frame(width: 96, height: 96)
+                        Text(pokemon.name)
+                            .font(.headline)
+                            .fontWeight(.semibold)
                     }
+                    .padding(8)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(color(for: pokemon.primaryType)))
                 }
-                .padding()
             }
+            .listStyle(.plain)
             .navigationTitle("Pokédex")
         }
         .task {

--- a/pokedexSwiftUI/Models/Pokemon.swift
+++ b/pokedexSwiftUI/Models/Pokemon.swift
@@ -9,9 +9,17 @@ struct Pokemon: Identifiable {
     let id: Int
     let name: String
     let types: [String]
+    let height: Int
+    let weight: Int
+    let baseExperience: Int
+    let abilities: [String]
 
     var imageURL: URL {
         URL(string: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/\(id).png")!
+    }
+
+    var cryURL: URL {
+        URL(string: "https://raw.githubusercontent.com/PokeAPI/cries/main/cries/pokemon/latest/\(id).ogg")!
     }
 
     var primaryType: String { types.first ?? "" }

--- a/pokedexSwiftUI/ViewModels/PokedexViewModel.swift
+++ b/pokedexSwiftUI/ViewModels/PokedexViewModel.swift
@@ -5,9 +5,17 @@ struct PokemonDetail: Decodable {
         struct Info: Decodable { let name: String }
         let type: Info
     }
+    struct AbilityEntry: Decodable {
+        struct Info: Decodable { let name: String }
+        let ability: Info
+    }
     let id: Int
     let name: String
     let types: [TypeEntry]
+    let height: Int
+    let weight: Int
+    let base_experience: Int
+    let abilities: [AbilityEntry]
 }
 
 @MainActor
@@ -25,7 +33,16 @@ class PokedexViewModel: ObservableObject {
                 let (dData, _) = try await URLSession.shared.data(from: detailURL)
                 let detail = try JSONDecoder().decode(PokemonDetail.self, from: dData)
                 let types = detail.types.map { $0.type.name }
-                let pokemon = Pokemon(id: detail.id, name: detail.name.capitalized, types: types)
+                let abilities = detail.abilities.map { $0.ability.name }
+                let pokemon = Pokemon(
+                    id: detail.id,
+                    name: detail.name.capitalized,
+                    types: types,
+                    height: detail.height,
+                    weight: detail.weight,
+                    baseExperience: detail.base_experience,
+                    abilities: abilities
+                )
                 loaded.append(pokemon)
             }
             pokemon = loaded.sorted { $0.id < $1.id }

--- a/pokedexSwiftUI/Views/PokemonDetailView.swift
+++ b/pokedexSwiftUI/Views/PokemonDetailView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+import AVFoundation
+
+struct PokemonDetailView: View {
+    let pokemon: Pokemon
+    @State private var player: AVPlayer?
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                AsyncImage(url: pokemon.imageURL) { image in
+                    image.resizable()
+                        .aspectRatio(contentMode: .fit)
+                } placeholder: {
+                    ProgressView()
+                }
+                .frame(width: 150, height: 150)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("ID: \(pokemon.id)")
+                    Text("Name: \(pokemon.name)")
+                    Text("Types: \(pokemon.types.joined(separator: ", "))")
+                    Text("Height: \(pokemon.height)")
+                    Text("Weight: \(pokemon.weight)")
+                    Text("Base Experience: \(pokemon.baseExperience)")
+                    Text("Abilities: \(pokemon.abilities.joined(separator: ", "))")
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Button("Tocar Cry") {
+                    playCry()
+                }
+                .padding(.top, 16)
+            }
+            .padding()
+        }
+        .navigationTitle(pokemon.name)
+    }
+
+    private func playCry() {
+        let item = AVPlayerItem(url: pokemon.cryURL)
+        player = AVPlayer(playerItem: item)
+        player?.play()
+    }
+}
+
+#Preview {
+    PokemonDetailView(pokemon: Pokemon(id: 1, name: "Bulbasaur", types: ["grass"], height: 7, weight: 69, baseExperience: 64, abilities: ["overgrow"]))
+}


### PR DESCRIPTION
## Summary
- adjust color scheme to softer opacity
- show one Pokémon per line in a list
- navigate to a detail view when selecting a Pokémon
- show all Pokémon properties and allow playing the cry sound

## Testing
- `swiftc -typecheck pokedexSwiftUI/*.swift pokedexSwiftUI/Models/*.swift pokedexSwiftUI/ViewModels/*.swift pokedexSwiftUI/Views/*.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684735631040832e8c572d343dc65df7