### PR TITLE
Refactor navigation with HomeView

### DIFF
--- a/pokedexSwiftUI/AppNavigationView.swift
+++ b/pokedexSwiftUI/AppNavigationView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct AppNavigationView: View {
+    var body: some View {
+        NavigationStack {
+            HomeView()
+                .navigationDestination(for: Pokemon.self) { pokemon in
+                    PokemonDetailView(pokemon: pokemon)
+                }
+        }
+    }
+}
+
+#Preview {
+    AppNavigationView()
+}

--- a/pokedexSwiftUI/ContentView.swift
+++ b/pokedexSwiftUI/ContentView.swift
@@ -1,52 +1,8 @@
 import SwiftUI
 
 struct ContentView: View {
-    @StateObject private var viewModel = PokedexViewModel()
-
-    private func color(for type: String) -> Color {
-        switch type {
-        case "fire": return .red.opacity(0.3)
-        case "water": return .blue.opacity(0.3)
-        case "grass": return .green.opacity(0.3)
-        case "electric": return .yellow.opacity(0.3)
-        case "poison": return .purple.opacity(0.3)
-        case "bug": return .green.opacity(0.3)
-        case "ground": return .brown.opacity(0.3)
-        case "psychic": return .pink.opacity(0.3)
-        case "rock": return .gray.opacity(0.3)
-        case "ghost": return .indigo.opacity(0.3)
-        case "ice": return .cyan.opacity(0.3)
-        case "dragon": return .orange.opacity(0.3)
-        default: return Color(.systemGray6)
-        }
-    }
-
     var body: some View {
-        NavigationStack {
-            List(viewModel.pokemon) { pokemon in
-                NavigationLink(destination: PokemonDetailView(pokemon: pokemon)) {
-                    HStack {
-                        AsyncImage(url: pokemon.imageURL) { image in
-                            image.resizable()
-                                .aspectRatio(contentMode: .fit)
-                        } placeholder: {
-                            ProgressView()
-                        }
-                        .frame(width: 96, height: 96)
-                        Text(pokemon.name)
-                            .font(.headline)
-                            .fontWeight(.semibold)
-                    }
-                    .padding(8)
-                    .background(RoundedRectangle(cornerRadius: 8).fill(color(for: pokemon.primaryType)))
-                }
-            }
-            .listStyle(.plain)
-            .navigationTitle("Pokédex")
-        }
-        .task {
-            await viewModel.fetchPokemon()
-        }
+        AppNavigationView()
     }
 }
 

--- a/pokedexSwiftUI/Domain/Entities/Pokemon.swift
+++ b/pokedexSwiftUI/Domain/Entities/Pokemon.swift
@@ -5,7 +5,7 @@ struct PokemonEntry: Decodable {
     let url: String
 }
 
-struct Pokemon: Identifiable {
+struct Pokemon: Identifiable, Hashable {
     let id: Int
     let name: String
     let types: [String]

--- a/pokedexSwiftUI/Views/HomeView.swift
+++ b/pokedexSwiftUI/Views/HomeView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct HomeView: View {
+    @StateObject private var viewModel = PokedexViewModel()
+
+    private func color(for type: String) -> Color {
+        switch type {
+        case "fire": return .red.opacity(0.3)
+        case "water": return .blue.opacity(0.3)
+        case "grass": return .green.opacity(0.3)
+        case "electric": return .yellow.opacity(0.3)
+        case "poison": return .purple.opacity(0.3)
+        case "bug": return .green.opacity(0.3)
+        case "ground": return .brown.opacity(0.3)
+        case "psychic": return .pink.opacity(0.3)
+        case "rock": return .gray.opacity(0.3)
+        case "ghost": return .indigo.opacity(0.3)
+        case "ice": return .cyan.opacity(0.3)
+        case "dragon": return .orange.opacity(0.3)
+        default: return Color(.systemGray6)
+        }
+    }
+
+    var body: some View {
+        List(viewModel.pokemon) { pokemon in
+            NavigationLink(value: pokemon) {
+                HStack {
+                    AsyncImage(url: pokemon.imageURL) { image in
+                        image.resizable()
+                            .aspectRatio(contentMode: .fit)
+                    } placeholder: {
+                        ProgressView()
+                    }
+                    .frame(width: 96, height: 96)
+                    Text(pokemon.name)
+                        .font(.headline)
+                        .fontWeight(.semibold)
+                }
+                .padding(8)
+                .background(RoundedRectangle(cornerRadius: 8).fill(color(for: pokemon.primaryType)))
+            }
+        }
+        .listStyle(.plain)
+        .navigationTitle("Pokédex")
+        .task {
+            await viewModel.fetchPokemon()
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        HomeView()
+    }
+}

--- a/pokedexSwiftUI/pokedexSwiftUIApp.swift
+++ b/pokedexSwiftUI/pokedexSwiftUIApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct pokedexSwiftUIApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            AppNavigationView()
         }
     }
 }


### PR DESCRIPTION
## Summary
- move list view logic from `ContentView` to new `HomeView`
- create `AppNavigationView` containing the `NavigationStack`
- show `AppNavigationView` in the app entry point
- make `Pokemon` conform to `Hashable`

## Testing
- `swiftc -typecheck pokedexSwiftUI/*.swift pokedexSwiftUI/Data/**/*.swift pokedexSwiftUI/Domain/**/*.swift pokedexSwiftUI/ViewModels/*.swift pokedexSwiftUI/Views/*.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6848a0520738832e8b4103f2f337fdb7