### PR TITLE
Add multi-page navigation with Pokemon content

### DIFF
--- a/pokedexSwiftUI/AppNavigationView.swift
+++ b/pokedexSwiftUI/AppNavigationView.swift
@@ -2,11 +2,32 @@ import SwiftUI
 
 struct AppNavigationView: View {
     var body: some View {
-        NavigationStack {
-            HomeView()
-                .navigationDestination(for: Pokemon.self) { pokemon in
-                    PokemonDetailView(pokemon: pokemon)
-                }
+        TabView {
+            NavigationStack {
+                HomeView()
+                    .navigationDestination(for: Pokemon.self) { pokemon in
+                        PokemonDetailView(pokemon: pokemon)
+                    }
+            }
+            .tabItem { Label("Pokédex", systemImage: "list.bullet") }
+
+            NavigationStack {
+                RandomPokemonView()
+                    .navigationDestination(for: Pokemon.self) { pokemon in
+                        PokemonDetailView(pokemon: pokemon)
+                    }
+            }
+            .tabItem { Label("Random", systemImage: "shuffle") }
+
+            NavigationStack {
+                TypesView()
+            }
+            .tabItem { Label("Types", systemImage: "square.grid.2x2") }
+
+            NavigationStack {
+                AboutView()
+            }
+            .tabItem { Label("About", systemImage: "info.circle") }
         }
     }
 }

--- a/pokedexSwiftUI/Data/Repositories/PokemonRepositoryImpl.swift
+++ b/pokedexSwiftUI/Data/Repositories/PokemonRepositoryImpl.swift
@@ -16,4 +16,8 @@ class PokemonRepositoryImpl: PokemonRepository {
         }
         return list.sorted { $0.id < $1.id }
     }
+
+    func fetchPokemon(id: Int) async throws -> Pokemon {
+        try await service.fetchDetail(id: id)
+    }
 }

--- a/pokedexSwiftUI/Data/Services/PokemonService.swift
+++ b/pokedexSwiftUI/Data/Services/PokemonService.swift
@@ -26,4 +26,23 @@ class PokemonService {
             abilities: abilities
         )
     }
+
+    func fetchDetail(id: Int) async throws -> Pokemon {
+        guard let url = URL(string: "https://pokeapi.co/api/v2/pokemon/\(id)") else {
+            throw URLError(.badURL)
+        }
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let detail = try JSONDecoder().decode(PokemonDetail.self, from: data)
+        let types = detail.types.map { $0.type.name }
+        let abilities = detail.abilities.map { $0.ability.name }
+        return Pokemon(
+            id: detail.id,
+            name: detail.name.capitalized,
+            types: types,
+            height: detail.height,
+            weight: detail.weight,
+            baseExperience: detail.base_experience,
+            abilities: abilities
+        )
+    }
 }

--- a/pokedexSwiftUI/Domain/Repositories/PokemonRepository.swift
+++ b/pokedexSwiftUI/Domain/Repositories/PokemonRepository.swift
@@ -1,3 +1,4 @@
 protocol PokemonRepository {
     func fetchPokemonList() async throws -> [Pokemon]
+    func fetchPokemon(id: Int) async throws -> Pokemon
 }

--- a/pokedexSwiftUI/Domain/UseCases/FetchPokemonByIDUseCase.swift
+++ b/pokedexSwiftUI/Domain/UseCases/FetchPokemonByIDUseCase.swift
@@ -1,0 +1,7 @@
+struct FetchPokemonByIDUseCase {
+    let repository: PokemonRepository
+
+    func execute(id: Int) async throws -> Pokemon {
+        try await repository.fetchPokemon(id: id)
+    }
+}

--- a/pokedexSwiftUI/ViewModels/RandomPokemonViewModel.swift
+++ b/pokedexSwiftUI/ViewModels/RandomPokemonViewModel.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+@MainActor
+class RandomPokemonViewModel: ObservableObject {
+    @Published var pokemon: Pokemon?
+    private let fetchPokemonUseCase: FetchPokemonByIDUseCase
+
+    init(fetchPokemonUseCase: FetchPokemonByIDUseCase = FetchPokemonByIDUseCase(repository: PokemonRepositoryImpl())) {
+        self.fetchPokemonUseCase = fetchPokemonUseCase
+    }
+
+    func loadRandomPokemon() async {
+        let id = Int.random(in: 1...151)
+        do {
+            pokemon = try await fetchPokemonUseCase.execute(id: id)
+        } catch {
+            print("Failed to fetch Pokémon: \(error)")
+        }
+    }
+}

--- a/pokedexSwiftUI/Views/AboutView.swift
+++ b/pokedexSwiftUI/Views/AboutView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct AboutView: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("About")
+                    .font(.title2)
+                    .bold()
+                Text("This app showcases Pokémon fetched from PokeAPI. Swipe through the tabs to explore the Pokédex, view random Pokémon and learn about the different types.")
+                Text("Have fun catching them all!")
+            }
+            .padding()
+        }
+        .navigationTitle("About")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AboutView()
+    }
+}

--- a/pokedexSwiftUI/Views/RandomPokemonView.swift
+++ b/pokedexSwiftUI/Views/RandomPokemonView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct RandomPokemonView: View {
+    @StateObject private var viewModel = RandomPokemonViewModel()
+
+    var body: some View {
+        VStack(spacing: 16) {
+            if let pokemon = viewModel.pokemon {
+                NavigationLink(value: pokemon) {
+                    VStack {
+                        AsyncImage(url: pokemon.imageURL) { image in
+                            image.resizable()
+                                .aspectRatio(contentMode: .fit)
+                        } placeholder: {
+                            ProgressView()
+                        }
+                        .frame(width: 120, height: 120)
+                        Text(pokemon.name)
+                            .font(.headline)
+                    }
+                }
+            } else {
+                Text("Tap the button to load a Pokémon")
+            }
+
+            Button("Load Random Pokémon") {
+                Task { await viewModel.loadRandomPokemon() }
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+        .navigationTitle("Random")
+        .task {
+            if viewModel.pokemon == nil {
+                await viewModel.loadRandomPokemon()
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        RandomPokemonView()
+    }
+}

--- a/pokedexSwiftUI/Views/TypesView.swift
+++ b/pokedexSwiftUI/Views/TypesView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct TypesView: View {
+    private let types: [String] = [
+        "Normal", "Fire", "Water", "Grass", "Electric", "Ice",
+        "Fighting", "Poison", "Ground", "Flying", "Psychic", "Bug",
+        "Rock", "Ghost", "Dragon", "Dark", "Steel", "Fairy"
+    ]
+
+    var body: some View {
+        List(types, id: \.self) { type in
+            Text(type)
+        }
+        .navigationTitle("Types")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        TypesView()
+    }
+}


### PR DESCRIPTION
## Summary
- add TabView navigation across Pokédex sections
- support fetching a single Pokémon in repository and service
- add use case and view model to load random Pokémon
- create new views: Random, Types and About

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6848a5410aa4832ea6b6ae88ec8fb0fe