### PR TITLE
Add trivia view and navigation from Pokemon detail

### DIFF
--- a/pokedexSwiftUI/Views/PokemonDetailView.swift
+++ b/pokedexSwiftUI/Views/PokemonDetailView.swift
@@ -8,13 +8,15 @@ struct PokemonDetailView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 16) {
-                AsyncImage(url: pokemon.imageURL) { image in
-                    image.resizable()
-                        .aspectRatio(contentMode: .fit)
-                } placeholder: {
-                    ProgressView()
+                NavigationLink(destination: PokemonTriviaView(pokemon: pokemon)) {
+                    AsyncImage(url: pokemon.imageURL) { image in
+                        image.resizable()
+                            .aspectRatio(contentMode: .fit)
+                    } placeholder: {
+                        ProgressView()
+                    }
+                    .frame(width: 150, height: 150)
                 }
-                .frame(width: 150, height: 150)
 
                 VStack(alignment: .leading, spacing: 8) {
                     Text("ID: \(pokemon.id)")

--- a/pokedexSwiftUI/Views/PokemonTriviaView.swift
+++ b/pokedexSwiftUI/Views/PokemonTriviaView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct PokemonTriviaView: View {
+    let pokemon: Pokemon
+    
+    private let trivia: [Int: String] = [
+        1: "Bulbasaur is known to be both a plant and an animal. Its plant seed grows progressively larger as it absorbs nutrients.",
+        4: "Charmander's tail flame indicates its life force. If it is healthy, the flame burns brightly.",
+        7: "Squirtle's shell is not merely used for protection. The shell's rounded shape and the grooves on its surface help minimize resistance in water." 
+    ]
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(pokemon.name)
+                    .font(.title)
+                    .bold()
+                Text(trivia[pokemon.id] ?? "No trivia available for this Pokémon.")
+                    .font(.body)
+            }
+            .padding()
+        }
+        .navigationTitle("Trivia")
+    }
+}
+
+#Preview {
+    PokemonTriviaView(pokemon: Pokemon(id: 1, name: "Bulbasaur", types: ["grass"], height: 7, weight: 69, baseExperience: 64, abilities: ["overgrow"]))
+}


### PR DESCRIPTION
## Summary
- add `PokemonTriviaView` to display fun facts for selected Pokémon
- open trivia view from `PokemonDetailView` when tapping the Pokémon image

## Testing
- `swift test` *(fails: xcodebuild not available)*

------
https://chatgpt.com/codex/tasks/task_e_6848a8003e68832e8286a61e2ffcad7d