### PR TITLE
Add login flow and logout option

### DIFF
--- a/pokedexSwiftUI/ContentView.swift
+++ b/pokedexSwiftUI/ContentView.swift
@@ -1,8 +1,16 @@
 import SwiftUI
 
 struct ContentView: View {
+    @AppStorage("isLoggedIn") private var isLoggedIn = false
+
     var body: some View {
-        AppNavigationView()
+        if isLoggedIn {
+            AppNavigationView()
+        } else {
+            NavigationStack {
+                WelcomeView()
+            }
+        }
     }
 }
 

--- a/pokedexSwiftUI/Views/AboutView.swift
+++ b/pokedexSwiftUI/Views/AboutView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct AboutView: View {
+    @AppStorage("isLoggedIn") private var isLoggedIn = false
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
@@ -9,6 +11,11 @@ struct AboutView: View {
                     .bold()
                 Text("This app showcases Pokémon fetched from PokeAPI. Swipe through the tabs to explore the Pokédex, view random Pokémon and learn about the different types.")
                 Text("Have fun catching them all!")
+                Button("Logout") {
+                    isLoggedIn = false
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 20)
             }
             .padding()
         }

--- a/pokedexSwiftUI/Views/LoginView.swift
+++ b/pokedexSwiftUI/Views/LoginView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct LoginView: View {
+    @AppStorage("isLoggedIn") private var isLoggedIn = false
+    @State private var username = ""
+    @State private var password = ""
+    @State private var showError = false
+
+    var body: some View {
+        VStack(spacing: 16) {
+            TextField("Username", text: $username)
+                .textFieldStyle(.roundedBorder)
+            SecureField("Password", text: $password)
+                .textFieldStyle(.roundedBorder)
+            if showError {
+                Text("Invalid credentials")
+                    .foregroundColor(.red)
+            }
+            Button("Login") {
+                if username == "admin" && password == "admin" {
+                    isLoggedIn = true
+                } else {
+                    showError = true
+                }
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+        .navigationTitle("Login")
+    }
+}
+
+#Preview {
+    NavigationStack { LoginView() }
+}

--- a/pokedexSwiftUI/Views/WelcomeView.swift
+++ b/pokedexSwiftUI/Views/WelcomeView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct WelcomeView: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Welcome to Pokédex")
+                .font(.largeTitle)
+                .multilineTextAlignment(.center)
+            NavigationLink("Login", destination: LoginView())
+                .buttonStyle(.borderedProminent)
+        }
+        .padding()
+        .navigationTitle("Welcome")
+    }
+}
+
+#Preview {
+    NavigationStack { WelcomeView() }
+}

--- a/pokedexSwiftUI/pokedexSwiftUIApp.swift
+++ b/pokedexSwiftUI/pokedexSwiftUIApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct pokedexSwiftUIApp: App {
     var body: some Scene {
         WindowGroup {
-            AppNavigationView()
+            ContentView()
         }
     }
 }


### PR DESCRIPTION
## Summary
- add login and welcome screens
- show app navigation only after login
- provide logout button in the About tab

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6848ac5057d4832ebc15f3cc6b44c20a